### PR TITLE
Add GamePad Support to Help Wanted Mod with Portuguese Translation

### DIFF
--- a/HelpWanted/Framework/Menu/BaseQuestBoard.cs
+++ b/HelpWanted/Framework/Menu/BaseQuestBoard.cs
@@ -1,38 +1,171 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Quests;
 
-namespace weizinai.StardewValleyMod.HelpWanted.Framework.Menu;
-
-internal abstract class BaseQuestBoard : IClickableMenu
+namespace weizinai.StardewValleyMod.HelpWanted.Framework.Menu
 {
-    protected readonly ClickableComponent AcceptQuestButton;
-    protected string HoverTitle = "";
-    protected string HoverText = "";
-
-    protected int ShowingQuestId;
-    protected Quest? ShowingQuest;
-
-    protected Rectangle BoardRect = new(78 * 4, 52 * 4, 184 * 4, 102 * 4);
-    protected const int OptionIndex = -4200;
-
-    protected BaseQuestBoard() : base(0, 0, 0, 0, true)
+    internal abstract class BaseQuestBoard : IClickableMenu
     {
-        // 位置和大小逻辑
-        this.width = 338 * 4;
-        this.height = 198 * 4;
-        var center = Utility.getTopLeftPositionForCenteringOnScreen(this.width, this.height);
-        this.xPositionOnScreen = (int)center.X;
-        this.yPositionOnScreen = (int)center.Y;
+        protected readonly ClickableComponent AcceptQuestButton;
+        protected string HoverTitle = "";
+        protected string HoverText = "";
+        protected int ShowingQuestId;
+        protected Quest? ShowingQuest;
 
-        // 接受任务按钮逻辑
-        var stringSize = Game1.dialogueFont.MeasureString(Game1.content.LoadString("Strings\\UI:AcceptQuest"));
-        this.AcceptQuestButton = new ClickableComponent(new Rectangle(this.xPositionOnScreen + this.width / 2 - 128, this.yPositionOnScreen + this.height - 128,
-            (int)stringSize.X + 24, (int)stringSize.Y + 24), "");
+        protected bool IsShowingQuest => ShowingQuest is not null;
 
-        // 关闭按钮逻辑
-        this.upperRightCloseButton = new ClickableTextureComponent(new Rectangle(this.xPositionOnScreen + this.width - 20, this.yPositionOnScreen, 48, 48),
-            Game1.mouseCursors, new Rectangle(337, 494, 12, 12), 4f);
+        protected Rectangle BoardRect = new(78 * 4, 52 * 4, 184 * 4, 102 * 4);
+        protected const int OptionIndex = -4200;
+
+        // Construtor
+        protected BaseQuestBoard()
+            : base(0, 0, 0, 0, true)
+        {
+            // 位置和大小逻辑
+            this.width = 338 * 4;
+            this.height = 198 * 4;
+            var center = Utility.getTopLeftPositionForCenteringOnScreen(this.width, this.height);
+            this.xPositionOnScreen = (int)center.X;
+            this.yPositionOnScreen = (int)center.Y;
+
+            // 接受任务按钮逻辑
+            var stringSize = Game1.dialogueFont.MeasureString(Game1.content.LoadString("Strings\\UI:AcceptQuest"));
+            this.AcceptQuestButton = new ClickableComponent(new Rectangle(this.xPositionOnScreen + this.width / 2 - 128, this.yPositionOnScreen + this.height - 128,
+                (int)stringSize.X + 24, (int)stringSize.Y + 24), "");
+
+            // 关闭按钮逻辑
+            this.upperRightCloseButton = new ClickableTextureComponent(new Rectangle(this.xPositionOnScreen + this.width - 20, this.yPositionOnScreen, 48, 48),
+                Game1.mouseCursors, new Rectangle(337, 494, 12, 12), 4f);
+        }
+
+
+        public override void receiveKeyPress(Keys key)
+        {
+            if (IsExitButtonPressed(key) && IsShowingQuest)
+            {
+                CloseQuestView();
+                return;
+            }
+
+            base.receiveKeyPress(key);
+        }
+
+        private bool IsExitButtonPressed(Keys key)
+        {
+            return Game1.options.doesInputListContain(Game1.options.menuButton, key)
+                || Game1.options.doesInputListContain(Game1.options.cancelButton, key);
+        }
+
+        protected void CloseQuestView()
+        {
+            ShowingQuest = null;
+            ShowingQuestId = -1;
+            AcceptQuestButton.visible = false;
+        }
+
+        public override void applyMovementKey(int direction)
+        {
+            if (allClickableComponents == null)
+            {
+                populateClickableComponentList();
+            }
+
+            moveCursorInDirection(direction);
+        }
+
+        public new void moveCursorInDirection(int direction)
+        {
+            if (IsShowingQuest)
+            {
+                ToggleQuestButtons();
+                return;
+            }
+
+            if (currentlySnappedComponent == null)
+            {
+                SnapToDefaultComponent();
+            }
+
+            NavigateToNextComponent(direction);
+        }
+
+        private void ToggleQuestButtons()
+        {
+            currentlySnappedComponent = (currentlySnappedComponent == AcceptQuestButton)
+                ? upperRightCloseButton
+                : AcceptQuestButton;
+
+            snapCursorToCurrentSnappedComponent();
+            Game1.playSound("toolSwap");
+        }
+
+        private void SnapToDefaultComponent()
+        {
+            var list = allClickableComponents;
+            if (list != null && list.Count > 0)
+            {
+                snapToDefaultClickableComponent();
+                currentlySnappedComponent ??= allClickableComponents[0];
+            }
+        }
+
+        private void NavigateToNextComponent(int direction)
+        {
+            var nextComponent = FindNextComponent(direction);
+            if (nextComponent != null)
+            {
+                currentlySnappedComponent = nextComponent;
+                snapCursorToCurrentNote();
+                Game1.playSound("toolSwap");
+            }
+        }
+
+        private ClickableComponent? FindNextComponent(int direction)
+        {
+            if (allClickableComponents == null || currentlySnappedComponent == null)
+                return null;
+
+            int currentX = currentlySnappedComponent.bounds.X;
+            int currentY = currentlySnappedComponent.bounds.Y;
+
+            var candidates = direction switch
+            {
+                0 => allClickableComponents.Where(c => c.bounds.Y < currentY),
+                1 => allClickableComponents.Where(c => c.bounds.X > currentX),
+                2 => allClickableComponents.Where(c => c.bounds.Y > currentY),
+                3 => allClickableComponents.Where(c => c.bounds.X < currentX),
+                _ => Enumerable.Empty<ClickableComponent>(),
+            };
+
+            return candidates
+                .OrderBy(c => GetDistance(c, currentX, currentY, direction))
+                .FirstOrDefault();
+        }
+
+        private static int GetDistance(ClickableComponent c, int currentX, int currentY, int direction)
+        {
+            return direction switch
+            {
+                0 => currentY - c.bounds.Center.Y,
+                1 => c.bounds.Center.X - currentX,
+                2 => c.bounds.Center.Y - currentY,
+                3 => currentX - c.bounds.Center.X,
+                _ => 0,
+            };
+        }
+
+        private void snapCursorToCurrentNote()
+        {
+            if (currentlySnappedComponent != null)
+            {
+                Game1.setMousePosition(
+                    currentlySnappedComponent.bounds.Center.X,
+                    currentlySnappedComponent.bounds.Bottom - currentlySnappedComponent.bounds.Height / 15,
+                    ui_scale: true
+                );
+            }
+        }
     }
 }

--- a/HelpWanted/i18n/pt.json
+++ b/HelpWanted/i18n/pt.json
@@ -1,0 +1,76 @@
+﻿{
+  // Configurações Gerais
+  "Config.GeneralSettingsTitle.Name": "Configurações Gerais",
+  "Config.OpenConfigMenuKeybind.Name": "Tecla de Atalho para Abrir o Menu de Configurações",
+  "Config.QuestFirstDay.Name": "Primeiro Dia de Missão",
+  "Config.QuestFirstDay.Tooltip": "Quando esta opção está desativada, o jogo não gerará missões no primeiro dia, como no jogo original.",
+  "Config.QuestFestival.Name": "Missão de Festival",
+  "Config.QuestFestival.Tooltip": "Quando esta opção está desativada, se hoje ou amanhã for um festival, a missão não será gerada, como no jogo original.",
+  "Config.DailyQuestChance.Name": "Chance de Missão Diária",
+  "Config.OneQuestPerVillager.Name": "Uma Missão por Habitante",
+  "Config.ExcludeMaxHeartsNPC.Name": "Excluir NPCs com Máximos de Coração",
+  "Config.ExcludeNPCList.Name": "Lista de NPCs Excluídos",
+  "Config.ExcludeNPCList.Tooltip": "Lista de NPCs excluídos. Cada nome de NPC é separado por vírgula. (ex.: \"Lewis, Marnie\")",
+  "Config.QuestDays.Name": "Dias de Missão",
+  "Config.QuestDays.Tooltip": "O limite de tempo para completar a missão",
+  "Config.MaxQuests.Name": "Máximo de Missões",
+  "Config.MaxQuests.Tooltip": "O número máximo de missões por dia é limitado pelo número de notas adesivas que podem ser colocadas no quadro de avisos",
+  "Config.EnableRSVQuestBoard.Name": "Ativar Quadro de Missões RSV",
+  "Config.MaxRSVQuests.Name": "Máximo de Missões RSV",
+
+  // Entrega de Itens
+  "Config.ItemDeliveryPage.Name": "Missão de Entrega de Itens",
+  "Config.ItemDeliveryWeight.Name": "Peso da Entrega de Itens",
+  "Config.ItemDeliveryWeight.Tooltip": "O peso da missão de entrega de itens.",
+  "Config.ItemDeliveryRewardMultiplier.Name": "Multiplicador de Recompensa de Entrega de Itens",
+  "Config.ItemDeliveryFriendshipGain.Name": "Ganho de Amizade por Entrega de Itens",
+  "Config.ItemDeliveryFriendshipGain.Tooltip": "O valor desta opção requer uma reinicialização do jogo para ter efeito.",
+  "Config.QuestItemSettingsTitle.Name": "Configurações de Itens da Missão",
+  "Config.QuestItemRequirement.Name": "Requisito de Item da Missão",
+  "Config.QuestItemRequirement.Tooltip": "Requisitos de itens para a missão de entrega de itens. Se for 0, significa que o item deve ser pelo menos amado. Se for 1, significa que o item deve ser pelo menos apreciado. Se for 2, significa que o item deve ser pelo menos neutro. Se for 3, significa que o item deve ser pelo menos desaprovado. Se for 4, significa que o item deve ser pelo menos odiado.",
+  "Config.MaxPrice.Name": "Preço Máximo",
+  "Config.MaxPrice.Tooltip": "O preço máximo para um item de missão. Se for -1, não há limite.",
+  "Config.AllowArtisanGoods.Name": "Permitir Produtos Artesanais",
+  "Config.AllowArtisanGoods.Tooltip": "Se o item da missão de entrega pode ser um Produto Artesanal",
+  "Config.UseModPossibleItems.Name": "Usar Lista de Itens Possíveis do Mod",
+  "Config.UseModPossibleItems.Tooltip": "Quando esta opção está ativada, os itens para a missão de entrega de itens são selecionados aleatoriamente entre todos os itens que atendem aos requisitos de itens da opção. Quando esta opção está desativada, os itens para a missão de entrega de itens são selecionados aleatoriamente a partir da lista original de itens de missão de entrega de itens.",
+
+  // Coleta de Recursos
+  "Config.ResourceCollectionPage.Name": "Missão de Coleta de Recursos",
+  "Config.ResourceCollectionWeight.Name": "Peso da Coleta de Recursos",
+  "Config.ResourceCollectionWeight.Tooltip": "O peso da missão de coleta de recursos.",
+  "Config.ResourceCollectionRewardMultiplier.Name": "Multiplicador de Recompensa de Coleta de Recursos",
+
+  // Pesca
+  "Config.FishingPage.Name": "Missão de Pesca",
+  "Config.FishingWeight.Name": "Peso da Pesca",
+  "Config.FishingWeight.Tooltip": "O peso da missão de pesca.",
+  "Config.FishingRewardMultiplier.Name": "Multiplicador de Recompensa de Pesca",
+
+  // Caça a Monstros
+  "Config.SlayMonstersPage.Name": "Missão de Caça a Monstros",
+  "Config.SlayMonstersWeight.Name": "Peso da Caça a Monstros",
+  "Config.SlayMonstersWeight.Tooltip": "O peso da missão de caçar monstros. As missões de caça a monstros devem ter atingido as minas e ter mais de 6 dias no jogo.",
+  "Config.SlayMonstersRewardMultiplier.Name": "Multiplicador de Recompensa de Caça a Monstros",
+  "Config.MoreSlayMonsterQuests.Name": "Mais Missões de Caça a Monstros",
+  "Config.MoreSlayMonsterQuests.Tooltip": "Quando esta opção está ativada, mais monstros serão alvo da missão de caça a monstros.",
+
+  // Aparência
+  "Config.AppearancePage.Name": "Aparência",
+  "Config.NoteAppearanceTitle.Name": "Aparência das Notas",
+  "Config.NoteScale.Name": "Escala da Nota",
+  "Config.XOverlapBoundary.Name": "Limite de Sobreposição X",
+  "Config.XOverlapBoundary.Tooltip": "Taxa de sobreposição horizontal das notas de missão. Se você definir como 1, não haverá sobreposição, se definir como 0,5, pode haver sobreposição de metade, e se definir como 0, pode haver sobreposição total.",
+  "Config.YOverlapBoundary.Name": "Limite de Sobreposição Y",
+  "Config.YOverlapBoundary.Tooltip": "Taxa de sobreposição vertical das notas de missão. Se você definir como 1, não haverá sobreposição, se definir como 0,5, pode haver sobreposição de metade, e se definir como 0, pode haver sobreposição total.",
+  "Config.RandomColorMin.Name": "Cor Aleatória Mínima",
+  "Config.RandomColorMax.Name": "Cor Aleatória Máxima",
+  "Config.PortraitAppearanceTitle.Name": "Aparência do Retrato",
+  "Config.PortraitScale.Name": "Escala do Retrato",
+  "Config.PortraitOffsetX.Name": "Deslocamento X do Retrato",
+  "Config.PortraitOffsetY.Name": "Deslocamento Y do Retrato",
+  "Config.PortraitTintR.Name": "Cor do Retrato R",
+  "Config.PortraitTintG.Name": "Cor do Retrato G",
+  "Config.PortraitTintB.Name": "Cor do Retrato B",
+  "Config.PortraitTintA.Name": "Cor do Retrato A"
+}


### PR DESCRIPTION
This update adds GamePad support to the "Help Wanted" mod. I play using a controller and noticed the lack of support for it, so I decided to implement this feature. Additionally, I've included the Portuguese translation for the mod, making it more accessible for Portuguese-speaking users.
